### PR TITLE
Add Flask email client with local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-"# super-duper-octo-succotash" 
+# super-duper-octo-succotash
+
+Simple Flask-based web email client and storage for the `chargepath.co` domain.
+
+## Features
+- Compose and send email using configurable SMTP settings
+- Store sent messages in a local SQLite database
+- Minimal web UI for viewing inbox and composing messages
+
+## Running the app
+```bash
+pip install -r requirements.txt
+python app.py
+```
+The application creates an `emails.db` SQLite database in the project directory.
+
+To enable SMTP sending, set the following environment variables before running:
+```bash
+export SMTP_SERVER=smtp.chargepath.co
+export SMTP_PORT=587  # optional, defaults to 587
+export SMTP_USER=your_username  # optional
+export SMTP_PASS=your_password  # optional
+export SMTP_TLS=1               # optional, defaults to 1
+```
+Without `SMTP_SERVER`, messages are only stored locally.
+
+## Tests
+Run `pytest` to execute the unit tests.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+import os
+import smtplib
+from email.message import EmailMessage
+
+from flask import Flask, request, redirect, url_for, render_template
+from flask_sqlalchemy import SQLAlchemy
+
+app = Flask(__name__)
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///emails.db"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+db = SQLAlchemy(app)
+
+
+class Email(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    sender = db.Column(db.String(255), nullable=False)
+    recipient = db.Column(db.String(255), nullable=False)
+    subject = db.Column(db.String(255), nullable=False)
+    body = db.Column(db.Text, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+@app.route("/")
+def index():
+    emails = Email.query.order_by(Email.timestamp.desc()).all()
+    return render_template("index.html", emails=emails)
+
+
+@app.route("/compose")
+def compose():
+    return render_template("compose.html")
+
+
+@app.route("/send", methods=["POST"])
+def send():
+    sender = request.form.get("sender")
+    recipient = request.form.get("recipient")
+    subject = request.form.get("subject")
+    body = request.form.get("body")
+
+    smtp_server = os.getenv("SMTP_SERVER")
+    if smtp_server:
+        msg = EmailMessage()
+        msg["Subject"] = subject
+        msg["From"] = sender
+        msg["To"] = recipient
+        msg.set_content(body)
+
+        with smtplib.SMTP(smtp_server, int(os.getenv("SMTP_PORT", 587))) as server:
+            if os.getenv("SMTP_TLS", "1") == "1":
+                server.starttls()
+            user = os.getenv("SMTP_USER")
+            password = os.getenv("SMTP_PASS")
+            if user and password:
+                server.login(user, password)
+            server.send_message(msg)
+
+    email = Email(sender=sender, recipient=recipient, subject=subject, body=body)
+    db.session.add(email)
+    db.session.commit()
+    return redirect(url_for("index"))
+
+
+if __name__ == "__main__":
+    with app.app_context():
+        db.create_all()
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=2.3.2
+Flask-SQLAlchemy>=3.0.5
+pytest>=7.3.1

--- a/templates/compose.html
+++ b/templates/compose.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head><title>Compose - ChargePath Mail</title></head>
+<body>
+<h1>Compose</h1>
+<form action="{{ url_for('send') }}" method="post">
+<label>From: <input type="email" name="sender" value="user@chargepath.co" required></label><br>
+<label>To: <input type="email" name="recipient" required></label><br>
+<label>Subject: <input type="text" name="subject" required></label><br>
+<label>Body:<br><textarea name="body" rows="10" cols="40" required></textarea></label><br>
+<button type="submit">Send</button>
+</form>
+<a href="{{ url_for('index') }}">Back to inbox</a>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head><title>ChargePath Mail</title></head>
+<body>
+<h1>Inbox</h1>
+<ul>
+{% for email in emails %}
+<li><strong>{{ email.subject }}</strong> from {{ email.sender }} to {{ email.recipient }} on {{ email.timestamp }}<br>{{ email.body }}</li>
+{% else %}
+<li>No messages</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('compose') }}">Compose</a>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, Email
+
+
+@pytest.fixture
+def client():
+    db_fd, db_path = tempfile.mkstemp()
+    app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{db_path}"
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+    yield app.test_client()
+    os.close(db_fd)
+    os.unlink(db_path)
+
+
+def test_email_storage(client):
+    data = {
+        "sender": "tester@chargepath.co",
+        "recipient": "user@example.com",
+        "subject": "Test subject",
+        "body": "Hello from tests",
+    }
+    response = client.post("/send", data=data, follow_redirects=True)
+    assert response.status_code == 200
+    assert b"Test subject" in response.data
+    with app.app_context():
+        saved = Email.query.first()
+        assert saved.sender == data["sender"]
+        assert saved.recipient == data["recipient"]


### PR DESCRIPTION
## Summary
- implement Flask app with SQLite-backed `Email` model and SMTP sending
- add minimal inbox and compose templates for chargepath.co
- include pytest verifying message persistence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c075ecb7848327b22c6f1418848c4b